### PR TITLE
Fix for exception StartIndex cannot be less than zero. P

### DIFF
--- a/WebApiClientGenShared/ClientApiFunctionGen.cs
+++ b/WebApiClientGenShared/ClientApiFunctionGen.cs
@@ -406,6 +406,9 @@ namespace Fonlow.CodeDom.Web.Cs
 		static string RemoveTrialEmptyString(string s)
 		{
 			var p = s.IndexOf("+\"\"");
+			if (p == -1) {
+				return s;
+			}
 			return s.Remove(p, 3);
 		}
 


### PR DESCRIPTION
fix for exception

[15:04:05 ERR] [0HLJNOD2DO2HK:00000002] StartIndex cannot be less than zero.
Parameter name: startIndex
System.ArgumentOutOfRangeException: StartIndex cannot be less than zero.
Parameter name: startIndex
   at System.String.Remove(Int32 startIndex, Int32 count)
   at Fonlow.CodeDom.Web.Cs.ClientApiFunctionGen.RemoveTrialEmptyString(String s) in c:\_work\oss\webapiclientgen\WebApiClientGenShared\ClientApiFunctionGen.cs:line 409
   at Fonlow.CodeDom.Web.Cs.ClientApiFunctionGen.<RenderPostOrPutImplementation>b__21_4() in c:\_work\oss\webapiclientgen\WebApiClientGenShared\ClientApiFunctionGen.cs:line 301
   at Fonlow.CodeDom.Web.Cs.ClientApiFunctionGen.RenderPostOrPutImplementation(Boolean isPost) in c:\_work\oss\webapiclientgen\WebApiClientGenShared\ClientApiFunctionGen.cs:line 332
   at Fonlow.CodeDom.Web.Cs.ClientApiFunctionGen.CreateApiFunction() in c:\_work\oss\webapiclientgen\WebApiClientGenShared\ClientApiFunctionGen.cs:line 93
   at Fonlow.CodeDom.Web.Cs.ClientApiFunctionGen.Create(SharedContext sharedContext, WebApiDescription description, IPoco2Client poco2CsGen, Boolean stringAsString, Boolean forAsync) in c:\_work\oss\webapiclientgen\WebApiClientGenShared\ClientApiFunctionGen.cs:line 50
   at Fonlow.CodeDom.Web.Cs.ControllersClientApiGen.CreateCodeDom(WebApiDescription[] descriptions) in c:\_work\oss\webapiclientgen\WebApiClientGenShared\ControllersClientApiGen.cs:line 141
   at Fonlow.CodeDom.Web.CodeGen.GenerateClientAPIs(String webRootPath, CodeGenSettings settings, WebApiDescription[] apiDescriptions) in c:\_work\oss\webapiclientgen\WebApiClientGenShared\CodeGen.cs:line 31